### PR TITLE
fix: improve package.json serialization

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -10,17 +10,19 @@ use pacquet_registry::RegistryManager;
 
 pub async fn run_commands() -> Result<()> {
     let current_directory = env::current_dir().context("problem fetching current directory")?;
+    let package_json_path = current_directory.join("package.json");
     let cli = Cli::parse();
 
     match &cli.subcommand {
         Subcommands::Init => {
             // init command throws an error if package.json file exist.
-            PackageJson::create()?;
+            PackageJson::init(&package_json_path)?;
         }
         Subcommands::Add(args) => {
             let mut registry_manager = RegistryManager::new(
                 current_directory.join("node_modules"),
                 current_directory.join(&args.virtual_store_dir),
+                package_json_path,
             )?;
             registry_manager.prepare()?;
             registry_manager.add_dependency(&args.package).await?;

--- a/crates/package_json/src/error.rs
+++ b/crates/package_json/src/error.rs
@@ -2,10 +2,12 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum PackageJsonError {
-    #[error("serialization failed: `${0}")]
+    #[error("serialization failed: {0}")]
     Serialization(#[from] serde_json::Error),
     #[error("io error: `{0}`")]
     Io(#[from] std::io::Error),
     #[error("package.json file already exists")]
     AlreadyExist,
+    #[error("invalid attribute: {0}")]
+    InvalidAttribute(String),
 }

--- a/crates/package_json/src/lib.rs
+++ b/crates/package_json/src/lib.rs
@@ -1,117 +1,92 @@
 pub mod error;
 
 use std::{
-    collections::HashMap,
-    env,
     ffi::OsStr,
     fs,
     io::{Read, Write},
     path::PathBuf,
 };
 
-use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
 
 use crate::error::PackageJsonError;
 
-#[derive(Debug, Serialize, Deserialize)]
 pub struct PackageJson {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    version: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    main: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    author: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    license: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    dependencies: Option<HashMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(alias = "devDependencies")]
-    dev_dependencies: Option<HashMap<String, String>>,
-}
-
-impl Default for PackageJson {
-    fn default() -> Self {
-        PackageJson::new()
-    }
+    path: PathBuf,
+    value: Value,
 }
 
 impl PackageJson {
-    pub fn new() -> PackageJson {
-        PackageJson {
-            name: Some("".to_string()),
-            version: Some("1.0.0".to_string()),
-            description: Some("".to_string()),
-            main: Some("index.js".to_string()),
-            author: Some("".to_string()),
-            license: Some("MIT".to_string()),
-            dependencies: None,
-            dev_dependencies: None,
-        }
+    pub fn new(path: PathBuf, value: Value) -> PackageJson {
+        PackageJson { path, value }
     }
 
-    pub fn path() -> Result<PathBuf, PackageJsonError> {
-        Ok(env::current_dir()?.join("package.json"))
-    }
-
-    fn write_to_file(path: &PathBuf) -> Result<PackageJson, PackageJsonError> {
+    fn write_to_file(path: &PathBuf) -> Result<Value, PackageJsonError> {
         let mut file = fs::File::create(path)?;
-        let mut package = PackageJson::new();
-        if let Some(parent_folder) = path.parent() {
-            package.name = Some(
-                parent_folder
-                    .file_name()
-                    .unwrap_or(OsStr::new(""))
-                    .to_str()
-                    .unwrap_or("")
-                    .to_string(),
-            )
+        let mut name = "";
+        if let Some(folder) = path.parent() {
+            // Set the default package name as the folder of the current directory
+            name = folder.file_name().unwrap_or(OsStr::new("")).to_str().unwrap();
         }
-        let contents = serde_json::to_string_pretty(&package)?;
+        let package_json = json!({
+            "name": name,
+            "version": "1.0.0",
+            "description": "",
+            "main": "index.js",
+            "author": "",
+            "license": "MIT",
+        });
+        let contents = serde_json::to_string_pretty(&package_json)?;
         file.write_all(contents.as_bytes())?;
-        Ok(package)
+        Ok(package_json)
     }
 
-    pub fn create() -> Result<PackageJson, PackageJsonError> {
-        let path = PackageJson::path()?;
-        if path.exists() {
-            return Err(PackageJsonError::AlreadyExist);
-        }
-
-        PackageJson::write_to_file(&path)
-    }
-
-    pub fn create_if_needed() -> Result<PackageJson, PackageJsonError> {
-        let path = PackageJson::path()?;
-        if !path.exists() {
-            return PackageJson::write_to_file(&path);
-        }
-
-        let mut file = fs::File::open(&path)?;
+    fn read_from_file(path: &PathBuf) -> Result<Value, PackageJsonError> {
+        let mut file = fs::File::open(path)?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
         Ok(serde_json::from_str(&contents)?)
     }
 
+    pub fn init(path: &PathBuf) -> Result<(), PackageJsonError> {
+        if path.exists() {
+            return Err(PackageJsonError::AlreadyExist);
+        }
+        PackageJson::write_to_file(path)?;
+        Ok(())
+    }
+
+    pub fn create_if_needed(path: &PathBuf) -> Result<PackageJson, PackageJsonError> {
+        let value = if path.exists() {
+            PackageJson::read_from_file(path)?
+        } else {
+            PackageJson::write_to_file(path)?
+        };
+
+        Ok(PackageJson::new(path.to_path_buf(), value))
+    }
+
     pub fn save(&mut self) -> Result<(), PackageJsonError> {
-        let path = PackageJson::path()?;
-        let mut file = fs::File::create(path)?;
-        let contents = serde_json::to_string_pretty(&self)?;
+        let mut file = fs::File::create(&self.path)?;
+        let contents = serde_json::to_string_pretty(&self.value)?;
         file.write_all(contents.as_bytes())?;
         Ok(())
     }
 
-    pub fn add_dependency(&mut self, name: &str, version: &str) {
-        if let Some(dependencies) = self.dependencies.as_mut() {
-            dependencies.insert(name.to_string(), version.to_string());
+    pub fn add_dependency(&mut self, name: &str, version: &str) -> Result<(), PackageJsonError> {
+        if let Some(field) = self.value.get_mut("dependencies") {
+            if let Some(dependencies) = field.as_object_mut() {
+                dependencies.insert(name.to_string(), Value::String(version.to_string()));
+            } else {
+                return Err(PackageJsonError::InvalidAttribute(
+                    "dependencies attribute should be an object".to_string(),
+                ));
+            }
         } else {
-            let mut dependencies = HashMap::<String, String>::new();
-            dependencies.insert(name.to_string(), version.to_string());
-            self.dependencies = Some(dependencies);
+            let mut dependencies = Map::<String, Value>::new();
+            dependencies.insert(name.to_string(), Value::String(version.to_string()));
+            self.value["dependencies"] = Value::Object(dependencies);
         }
+        Ok(())
     }
 }

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -28,12 +28,13 @@ impl RegistryManager {
     pub fn new<P: Into<PathBuf>>(
         node_modules_path: P,
         store_path: P,
+        package_json_path: P,
     ) -> Result<RegistryManager, RegistryError> {
         Ok(RegistryManager {
             client: Client::new(),
             node_modules_path: node_modules_path.into(),
             store_path: store_path.into(),
-            package_json: PackageJson::create_if_needed()?,
+            package_json: PackageJson::create_if_needed(&package_json_path.into())?,
         })
     }
 
@@ -76,7 +77,7 @@ impl RegistryManager {
         )
         .await;
 
-        self.package_json.add_dependency(name, &format!("^{0}", &latest_version.version));
+        self.package_json.add_dependency(name, &format!("^{0}", &latest_version.version))?;
         self.package_json.save()?;
 
         Ok(())


### PR DESCRIPTION
Previously, package.json serializer removed unknown attributes. We now use a serde_json::Value to define the value and store the reference to it.