### PR TITLE
feat: implement -D, -O options for add command

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use pacquet_package_json::DependencyGroup;
 
 /// Experimental package manager for node.js written in rust.
 #[derive(Parser, Debug)]
@@ -23,8 +24,26 @@ pub enum Subcommands {
 pub struct AddArgs {
     /// Name of the package
     pub package: String,
+    /// Add the package as a dev dependency
+    #[arg(short = 'D', long = "save-dev", group = "dependency_group")]
+    dev: bool,
+    /// Add the package as a optional dependency
+    #[arg(short = 'O', long = "save-optional", group = "dependency_group")]
+    optional: bool,
     /// The directory with links to the store (default is node_modules/.pacquet).
     /// All direct and indirect dependencies of the project are linked into this directory
     #[arg(long = "virtual-store-dir", default_value = "node_modules/.pacquet")]
     pub virtual_store_dir: String,
+}
+
+impl AddArgs {
+    pub fn get_dependency_group(&self) -> DependencyGroup {
+        if self.dev {
+            DependencyGroup::Dev
+        } else if self.optional {
+            DependencyGroup::Optional
+        } else {
+            DependencyGroup::Default
+        }
+    }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -30,7 +30,9 @@ pub async fn run_commands() -> Result<()> {
                 package_json_path,
             )?;
             registry_manager.prepare()?;
-            registry_manager.add_dependency(&args.package).await?;
+            // TODO if a package already exists in another dependency group, we don't remove
+            // the existing entry.
+            registry_manager.add_dependency(&args.package, args.get_dependency_group()).await?;
         }
     }
 

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
 
 use async_recursion::async_recursion;
 use futures_util::future::join_all;
-use pacquet_package_json::PackageJson;
+use pacquet_package_json::{DependencyGroup, PackageJson};
 use pacquet_tarball::{download_dependency, get_package_store_folder_name};
 
 use crate::{error::RegistryError, http_client::HttpClient};
@@ -42,7 +42,11 @@ impl RegistryManager {
         Ok(())
     }
 
-    pub async fn add_dependency(&mut self, name: &str) -> Result<(), RegistryError> {
+    pub async fn add_dependency(
+        &mut self,
+        name: &str,
+        dependency_group: DependencyGroup,
+    ) -> Result<(), RegistryError> {
         let latest_version = self.client.get_package_by_version(name, "latest").await?;
         let dependency_store_folder_name =
             get_package_store_folder_name(name, &latest_version.version.to_string());
@@ -80,7 +84,11 @@ impl RegistryManager {
         )
         .await;
 
-        self.package_json.add_dependency(name, &format!("^{0}", &latest_version.version))?;
+        self.package_json.add_dependency(
+            name,
+            &format!("^{0}", &latest_version.version),
+            dependency_group,
+        )?;
         self.package_json.save()?;
 
         Ok(())


### PR DESCRIPTION
One caveat is if a package already exists in another dependecy group, we don't remove the existing entry. Can we fix it in another PR?