### PR TITLE
fix: store_dir envs should without $ symbols

### DIFF
--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -81,9 +81,11 @@ where
 {
     let s = String::deserialize(deserializer)?;
     let path = PathBuf::from_str(&s).map_err(de::Error::custom)?;
+
     if path.is_absolute() {
         return Ok(path);
     }
+
     Ok(env::current_dir().map_err(de::Error::custom)?.join(path))
 }
 
@@ -93,9 +95,11 @@ where
     D: Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
+
     if s.ends_with('/') {
         return Ok(s);
     }
+
     Ok(format!("{s}/"))
 }
 

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -3,37 +3,30 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
-
 use serde::{de, Deserialize, Deserializer};
-
 // This needs to be implemented because serde doesn't support default = "true" as
 // a valid option, and throws  "failed to parse" error.
 pub fn bool_true() -> bool {
     true
 }
-
 pub fn default_hoist_pattern() -> Vec<String> {
     vec!["*".to_string()]
 }
-
 pub fn default_public_hoist_pattern() -> Vec<String> {
     vec!["*eslint*".to_string(), "*prettier*".to_string()]
 }
-
 /// If the $PACQUET_HOME env variable is set, then $PACQUET_HOME/store
 /// If the $XDG_DATA_HOME env variable is set, then $XDG_DATA_HOME/pacquet/store
 /// On Windows: ~/AppData/Local/pacquet/store
 /// On macOS: ~/Library/pacquet/store
 /// On Linux: ~/.local/share/pacquet/store
 pub fn default_store_dir() -> PathBuf {
-    if let Ok(pacquet_home) = env::var("$PACQUET_HOME") {
+    if let Ok(pacquet_home) = env::var("PACQUET_HOME") {
         return Path::new(&pacquet_home).join("store");
     }
-
-    if let Ok(xdg_data_home) = env::var("$XDG_DATA_HOME") {
+    if let Ok(xdg_data_home) = env::var("XDG_DATA_HOME") {
         return Path::new(&xdg_data_home).join("pacquet/store");
     }
-
     // https://doc.rust-lang.org/std/env/consts/constant.OS.html
     match env::consts::OS {
         "linux" => Path::new("~/.local/share/pacquet/store").to_path_buf(),
@@ -42,23 +35,18 @@ pub fn default_store_dir() -> PathBuf {
         _ => panic!("unsupported operating system: {0}", env::consts::OS),
     }
 }
-
 pub fn default_modules_dir() -> PathBuf {
     env::current_dir().expect("current directory is unavailable").join("node_modules")
 }
-
 pub fn default_virtual_store_dir() -> PathBuf {
     env::current_dir().expect("current directory is unavailable").join("node_modules/.pacquet")
 }
-
 pub fn default_registry() -> String {
     "https://registry.npmjs.org/".to_string()
 }
-
 pub fn default_modules_cache_max_age() -> u64 {
     10080
 }
-
 pub fn deserialize_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
 where
     D: Deserializer<'de>,
@@ -66,7 +54,6 @@ where
     let s = String::deserialize(deserializer)?;
     bool::from_str(&s).map_err(de::Error::custom)
 }
-
 pub fn deserialize_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>
 where
     D: Deserializer<'de>,
@@ -74,31 +61,44 @@ where
     let s = String::deserialize(deserializer)?;
     u64::from_str(&s).map_err(de::Error::custom)
 }
-
 pub fn deserialize_pathbuf<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>
 where
     D: Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
     let path = PathBuf::from_str(&s).map_err(de::Error::custom)?;
-
     if path.is_absolute() {
         return Ok(path);
     }
-
     Ok(env::current_dir().map_err(de::Error::custom)?.join(path))
 }
-
 /// This deserializer adds a trailing "/" if not exist to make our life easier.
 pub fn deserialize_registry<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
-
     if s.ends_with('/') {
         return Ok(s);
     }
-
     Ok(format!("{s}/"))
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    #[test]
+    fn test_default_store_dir_with_pac_env() {
+        env::set_var("PACQUET_HOME", "/tmp/pacquet_home");
+        let store_dir = default_store_dir();
+        assert_eq!(store_dir, Path::new("/tmp/pacquet_home/store"));
+        env::remove_var("PACQUET_HOME");
+    }
+    #[test]
+    fn test_default_store_dir_with_xdg_env() {
+        env::set_var("XDG_DATA_HOME", "/tmp/xdg_data_home");
+        let store_dir = default_store_dir();
+        assert_eq!(store_dir, Path::new("/tmp/xdg_data_home/pacquet/store"));
+        env::remove_var("XDG_DATA_HOME");
+    }
 }

--- a/crates/npmrc/src/custom_deserializer.rs
+++ b/crates/npmrc/src/custom_deserializer.rs
@@ -3,18 +3,23 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
+
 use serde::{de, Deserialize, Deserializer};
+
 // This needs to be implemented because serde doesn't support default = "true" as
 // a valid option, and throws  "failed to parse" error.
 pub fn bool_true() -> bool {
     true
 }
+
 pub fn default_hoist_pattern() -> Vec<String> {
     vec!["*".to_string()]
 }
+
 pub fn default_public_hoist_pattern() -> Vec<String> {
     vec!["*eslint*".to_string(), "*prettier*".to_string()]
 }
+
 /// If the $PACQUET_HOME env variable is set, then $PACQUET_HOME/store
 /// If the $XDG_DATA_HOME env variable is set, then $XDG_DATA_HOME/pacquet/store
 /// On Windows: ~/AppData/Local/pacquet/store
@@ -24,9 +29,11 @@ pub fn default_store_dir() -> PathBuf {
     if let Ok(pacquet_home) = env::var("PACQUET_HOME") {
         return Path::new(&pacquet_home).join("store");
     }
+
     if let Ok(xdg_data_home) = env::var("XDG_DATA_HOME") {
         return Path::new(&xdg_data_home).join("pacquet/store");
     }
+
     // https://doc.rust-lang.org/std/env/consts/constant.OS.html
     match env::consts::OS {
         "linux" => Path::new("~/.local/share/pacquet/store").to_path_buf(),
@@ -35,18 +42,23 @@ pub fn default_store_dir() -> PathBuf {
         _ => panic!("unsupported operating system: {0}", env::consts::OS),
     }
 }
+
 pub fn default_modules_dir() -> PathBuf {
     env::current_dir().expect("current directory is unavailable").join("node_modules")
 }
+
 pub fn default_virtual_store_dir() -> PathBuf {
     env::current_dir().expect("current directory is unavailable").join("node_modules/.pacquet")
 }
+
 pub fn default_registry() -> String {
     "https://registry.npmjs.org/".to_string()
 }
+
 pub fn default_modules_cache_max_age() -> u64 {
     10080
 }
+
 pub fn deserialize_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
 where
     D: Deserializer<'de>,
@@ -54,6 +66,7 @@ where
     let s = String::deserialize(deserializer)?;
     bool::from_str(&s).map_err(de::Error::custom)
 }
+
 pub fn deserialize_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>
 where
     D: Deserializer<'de>,
@@ -61,6 +74,7 @@ where
     let s = String::deserialize(deserializer)?;
     u64::from_str(&s).map_err(de::Error::custom)
 }
+
 pub fn deserialize_pathbuf<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>
 where
     D: Deserializer<'de>,
@@ -72,6 +86,7 @@ where
     }
     Ok(env::current_dir().map_err(de::Error::custom)?.join(path))
 }
+
 /// This deserializer adds a trailing "/" if not exist to make our life easier.
 pub fn deserialize_registry<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
@@ -83,10 +98,12 @@ where
     }
     Ok(format!("{s}/"))
 }
+
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::env;
+
+    use super::*;
     #[test]
     fn test_default_store_dir_with_pac_env() {
         env::set_var("PACQUET_HOME", "/tmp/pacquet_home");
@@ -94,6 +111,7 @@ mod tests {
         assert_eq!(store_dir, Path::new("/tmp/pacquet_home/store"));
         env::remove_var("PACQUET_HOME");
     }
+
     #[test]
     fn test_default_store_dir_with_xdg_env() {
         env::set_var("XDG_DATA_HOME", "/tmp/xdg_data_home");

--- a/crates/npmrc/src/lib.rs
+++ b/crates/npmrc/src/lib.rs
@@ -213,14 +213,14 @@ mod tests {
 
     #[test]
     pub fn should_use_pacquet_home_env_var() {
-        env::set_var("$PACQUET_HOME", "/hello");
+        env::set_var("PACQUET_HOME", "/hello");
         let value: Npmrc = serde_ini::from_str("").unwrap();
         assert_eq!(value.store_dir, PathBuf::from_str("/hello/store").unwrap());
     }
 
     #[test]
     pub fn should_use_xdg_data_home_env_var() {
-        env::set_var("$XDG_DATA_HOME", "/hello");
+        env::set_var("XDG_DATA_HOME", "/hello");
         let value: Npmrc = serde_ini::from_str("").unwrap();
         assert_eq!(value.store_dir, PathBuf::from_str("/hello/pacquet/store").unwrap());
     }


### PR DESCRIPTION
I think env should without `$` symbols.

`$` just for us to use it with bash.For example

```bash
echo $HOME
```
In rust , we should use it with these code:

```rs
let home = env::var('HOME')
```