### PR TITLE
feat: add initial benchmark

### DIFF
--- a/benchmark/.npmrc
+++ b/benchmark/.npmrc
@@ -1,0 +1,3 @@
+registry=http://localhost:4873
+auto-install-peers=false
+lockfile=false

--- a/benchmark/.yarnrc.yml
+++ b/benchmark/.yarnrc.yml
@@ -1,0 +1,3 @@
+npmRegistryServer: "http://localhost:4873"
+unsafeHttpWhitelist: ["localhost"]
+enableGlobalCache: false

--- a/benchmark/add.sh
+++ b/benchmark/add.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Make sure to create a .npmrc file
+# registry=http://localhost:4873
+
+PACQUET="../target/release/pacquet add fastify"
+PNPM="pnpm add fastify --silent"
+YARN="yarn add fastify --silent"
+BUN="bun add fastify --no-cache --no-save --silent"
+
+FILE_CLEAN="rm -rf package.json node_modules .yarn yarn.lock .pnp* && echo {} > package.json || true"
+PNPM_CLEAN="pnpm store prune"
+YARN_CLEAN="yarn cache clean --all"
+CLEANUP="${PNPM_CLEAN} && ${YARN_CLEAN} && ${FILE_CLEAN}"
+
+$FILE_CLEAN
+
+hyperfine -w 5 -i \
+  --prepare "${CLEANUP}" \
+  -n pacquet "${PACQUET}" \
+  -n pnpm "${PNPM}" \
+  -n yarn "${YARN}" \
+  -n bun "${BUN}"
+
+$FILE_CLEAN

--- a/benchmark/bunfig.toml
+++ b/benchmark/bunfig.toml
@@ -1,0 +1,12 @@
+[install]
+optional = false
+dev = false
+# The following does not work
+#registry = "http://localhost:4873/"
+
+[install.cache]
+disable = true
+disableManifest = true
+
+[install.lockfile]
+save = false


### PR DESCRIPTION
An initial pretty simplistic benchmark that uses verdaccio (to remove the overhead of http requests to npm registry).

```
Benchmark 1: pacquet
  Time (mean ± σ):     364.6 ms ±  21.1 ms    [User: 44.0 ms, System: 173.1 ms]
  Range (min … max):   337.3 ms … 406.7 ms    10 runs

Benchmark 2: pnpm
  Time (mean ± σ):     945.9 ms ±  43.4 ms    [User: 585.6 ms, System: 1491.7 ms]
  Range (min … max):   876.5 ms … 1003.7 ms    10 runs

Benchmark 3: yarn
  Time (mean ± σ):     610.5 ms ±   7.5 ms    [User: 1250.2 ms, System: 181.2 ms]
  Range (min … max):   601.8 ms … 624.2 ms    10 runs

Benchmark 4: bun
  Time (mean ± σ):      1.055 s ±  0.222 s    [User: 0.079 s, System: 0.306 s]
  Range (min … max):    0.733 s …  1.550 s    10 runs

Summary
  pacquet ran
    1.67 ± 0.10 times faster than yarn
    2.59 ± 0.19 times faster than pnpm
    2.89 ± 0.63 times faster than bun
```