### PR TITLE
fix pacquet executer

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -87,6 +87,10 @@ impl AddArgs {
 pub struct RunArgs {
     /// A pre-defined package script.
     pub command: String,
+
+    /// Any additional arguments passed after the script name
+    pub args: Vec<String>,
+
     /// You can use the --if-present flag to avoid exiting with a non-zero exit code when the
     /// script is undefined. This lets you run potentially undefined scripts without breaking the
     /// execution chain.

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -70,7 +70,12 @@ async fn run_commands(cli: Cli) -> Result<()> {
         Subcommands::Run(args) => {
             let package_json = PackageJson::from_path(&package_json_path)?;
             if let Some(script) = package_json.get_script(&args.command, args.if_present)? {
-                execute_shell(script)?;
+                let mut command = script.to_string();
+                // append an empty space between script and additional args
+                command.push(' ');
+                // then append the additional args
+                command.push_str(args.args.join(" ").as_str());
+                execute_shell(command.trim())?;
             }
         }
         Subcommands::Start => {

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -12,7 +12,7 @@ pub enum ExecutorError {
 }
 
 pub fn execute_shell(command: &str) -> Result<(), ExecutorError> {
-    let mut cmd = Command::new(command).spawn()?;
+    let mut cmd = Command::new("sh").arg("-c").arg(command).spawn()?;
 
     cmd.wait()?;
 


### PR DESCRIPTION
Until now pacquet just ran any script/shell commands by just directly passing the entire command to `Command::new`. As per the std, `Command::new` takes only the file/program name, and any additional args need to be provided via the `arg` or `args` method.

Well now, i just touched it a little bit, to run `sh -c` and pass the actual command/script to it. This runs without any errors now, and sometimes scripts contain env vars too. For example
```json
{
  "scripts": {
    "test": "KEY=VALUE node index.js"
  }
}
```
Now it is passed as `sh -c "KEY=ENV node index.js`. This seems to be how the peeps do it in pnpm. ([in pn](https://github.com/pnpm/pn/blob/8ed5abaaa90e3dcae783f763cdad3e289dbaca5e/src/main.rs#L111))

And also pass any sort of additional args provided in the run command to the script. For example, 
```json
{
  "scripts": {
    "test": "echo Hello"
  }
}
```
Current running `pacquet test` and `pacquet test World` both just prints "Hello", but pnpm passes any additional args provided to the script too. So now it prints "Hello World" when done `pacquet test World`
