### PR TITLE
feat: add better error reporting

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -1,3 +1,12 @@
+# Options
+
+[pnpm documentation](https://pnpm.io/pnpm-cli#options)
+
+| Done | Command                 | Notes |
+|------|-------------------------|-------|
+| ✅    | -C <path>, --dir <path> |       |
+|      | -w, --workspace-root    |       |
+
 # Manage dependencies
 
 ## `pacquet add <pkg>`

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::{Parser, Subcommand};
 use pacquet_package_json::DependencyGroup;
 
@@ -10,6 +12,10 @@ use pacquet_package_json::DependencyGroup;
 pub struct Cli {
     #[command(subcommand)]
     pub subcommand: Subcommands,
+
+    /// Run as if pacquet was started in <path> instead of the current working directory.
+    #[arg(short = 'C', long = "dir")]
+    pub current_dir: Option<PathBuf>,
 }
 
 #[derive(Subcommand, Debug)]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -41,7 +41,8 @@ pub async fn run_cli() -> Result<()> {
 }
 
 async fn run_commands(cli: Cli) -> Result<()> {
-    let current_directory = env::current_dir().expect("Getting current directory failed");
+    let current_directory =
+        cli.current_dir.unwrap_or(env::current_dir().expect("getting current directory failed"));
     let package_json_path = current_directory.join("package.json");
 
     match &cli.subcommand {
@@ -134,34 +135,26 @@ mod tests {
     #[tokio::test]
     async fn init_command_should_create_package_json() {
         let parent_folder = tempdir().unwrap();
-        let current_directory = env::current_dir().unwrap();
-        env::set_current_dir(parent_folder.path()).unwrap();
-        let cli = Cli::parse_from(["", "init"]);
+        let cli = Cli::parse_from(["", "-C", parent_folder.path().to_str().unwrap(), "init"]);
         run_commands(cli).await.unwrap();
         assert!(parent_folder.path().join("package.json").exists());
-        env::set_current_dir(&current_directory).unwrap();
     }
 
     #[tokio::test]
     async fn init_command_should_throw_on_existing_file() {
         let parent_folder = tempdir().unwrap();
-        let current_directory = env::current_dir().unwrap();
-        env::set_current_dir(&parent_folder).unwrap();
         let mut file = fs::File::create(parent_folder.path().join("package.json")).unwrap();
         file.write_all("{}".as_bytes()).unwrap();
         assert!(parent_folder.path().join("package.json").exists());
-        let cli = Cli::parse_from(["", "init"]);
+        let cli = Cli::parse_from(["", "-C", parent_folder.path().to_str().unwrap(), "init"]);
         run_commands(cli).await.expect_err("should have thrown");
-        env::set_current_dir(&current_directory).unwrap();
     }
 
     #[tokio::test]
     async fn should_get_store_path() {
         let parent_folder = tempdir().unwrap();
-        let current_directory = env::current_dir().unwrap();
-        env::set_current_dir(parent_folder.path()).unwrap();
-        let cli = Cli::parse_from(["", "store", "path"]);
+        let cli =
+            Cli::parse_from(["", "-C", parent_folder.path().to_str().unwrap(), "store", "path"]);
         run_commands(cli).await.unwrap();
-        env::set_current_dir(&current_directory).unwrap();
     }
 }

--- a/crates/package_manager/src/commands/install.rs
+++ b/crates/package_manager/src/commands/install.rs
@@ -6,7 +6,7 @@ use crate::PackageManager;
 
 impl PackageManager {
     pub async fn install(
-        &mut self,
+        &self,
         install_dev_dependencies: bool,
         install_optional_dependencies: bool,
     ) -> Result<(), RegistryError> {
@@ -58,7 +58,7 @@ mod tests {
 
         package_json.save().unwrap();
 
-        let mut package_manager = PackageManager::new(&package_json_path).unwrap();
+        let package_manager = PackageManager::new(&package_json_path).unwrap();
         package_manager.install(true, false).await.unwrap();
         // Make sure the package is installed
         assert!(dir.path().join("node_modules/is-odd").is_symlink());


### PR DESCRIPTION
Thanks @Yakiyo for reporting the lack of error messages. This would make finding the root cause of the error faster, I assume.

```
➜  pacquet git:(error-reporting) ✗ cargo run -- init
   Compiling pacquet_cli v0.0.1 (/Users/yagiz/Developer/pacquet/crates/cli)
    Finished dev [unoptimized + debuginfo] target(s) in 0.78s
     Running `target/debug/pacquet init`
Error: pacquet_package_json::already_exist_error

  × initialize package.json
  ╰─▶ package.json file already exists
  help: Your current working directory already has a package.json file.
```