### PR TITLE
Use Default

### DIFF
--- a/crates/registry/src/package.rs
+++ b/crates/registry/src/package.rs
@@ -55,7 +55,7 @@ mod tests {
         let version = PackageVersion {
             name: "".to_string(),
             version: Version::parse("1.0.0").unwrap(),
-            dist: PackageDistribution::empty(),
+            dist: PackageDistribution::default(),
             dependencies: Some(dependencies),
             dev_dependencies: None,
             peer_dependencies: Some(peer_dependencies),
@@ -73,7 +73,7 @@ mod tests {
         let version = PackageVersion {
             name: "".to_string(),
             version: Version { major: 3, minor: 2, patch: 1, build: vec![], pre_release: vec![] },
-            dist: PackageDistribution::empty(),
+            dist: PackageDistribution::default(),
             dependencies: None,
             dev_dependencies: None,
             peer_dependencies: None,

--- a/crates/registry/src/package_distribution.rs
+++ b/crates/registry/src/package_distribution.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct PackageDistribution {
     pub integrity: String,
     #[serde(alias = "npm-signature")]
@@ -11,17 +11,4 @@ pub struct PackageDistribution {
     pub file_count: Option<usize>,
     #[serde(alias = "unpackedSize")]
     pub unpacked_size: Option<usize>,
-}
-
-impl PackageDistribution {
-    pub fn empty() -> Self {
-        PackageDistribution {
-            integrity: "".to_string(),
-            npm_signature: None,
-            shasum: "".to_string(),
-            tarball: "".to_string(),
-            file_count: Some(0),
-            unpacked_size: Some(0),
-        }
-    }
 }


### PR DESCRIPTION
Doing this kind of thing has a standard trait/interface/API, so use it rather than some other kind of name.