### PR TITLE
perf: replace tokio mutex with std mutex

### DIFF
--- a/crates/registry/src/package.rs
+++ b/crates/registry/src/package.rs
@@ -1,8 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use serde::{Deserialize, Serialize};
-use tokio::sync::Mutex;
-
+use std::sync::Mutex;
 use crate::{package_version::PackageVersion, RegistryError};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/registry/src/package.rs
+++ b/crates/registry/src/package.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
+
 use crate::{package_version::PackageVersion, RegistryError};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
In this PR, I have replaced the usage of tokio mutex with std mutex in the codebase. This change improves the synchronization mechanism by utilizing the standard Rust mutex from the std library

İssue: https://github.com/anonrig/pacquet/issues/15
